### PR TITLE
fix: Jet get_response_matrix issue

### DIFF
--- a/ext/HarmonicBalanceExt.jl
+++ b/ext/HarmonicBalanceExt.jl
@@ -11,6 +11,9 @@ using QuestBase:
     d,
     var_name
 using HarmonicSteadyState: HarmonicSteadyState
+using HarmonicSteadyState: LinearResponse
+using HarmonicSteadyState.LinearResponse: ResponseMatrix
+using ProgressMeter: ProgressMeter, Progress, next!
 
 """
 $(TYPEDSIGNATURES)
@@ -20,9 +23,7 @@ This routine cannot accept a `HarmonicEquation` since there, some time-derivativ
 `order` denotes the highest differential order to be considered.
 
 """
-function HarmonicSteadyState.get_response_matrix(
-    diff_eq::DifferentialEquation, freq::Num; order=2
-)::Matrix
+function get_response_matrix(diff_eq::DifferentialEquation, freq::Num; order=2)::Matrix
     Symbolics.@variables T
     time = get_independent_variables(diff_eq)[1]
 
@@ -46,4 +47,77 @@ function HarmonicSteadyState.get_response_matrix(
     return M
 end
 
+"Get the response matrix corresponding to `res`.
+Any substitution rules not specified in `res` can be supplied in `rules`."
+function HarmonicSteadyState.LinearResponse.ResponseMatrix(
+    res::HarmonicSteadyState.Result; rules=Dict()
+)
+    # get the symbolic response matrix
+    Symbolics.@variables Δ
+    M = get_response_matrix(res.problem.eom.natural_equation, Num(Δ))
+    M = HarmonicSteadyState.QuestBase.substitute_all(M, merge(res.fixed_parameters, rules))
+    symbols = HarmonicSteadyState._free_symbols(res)
+
+    compiled_M = map(M) do el
+        args = cat(symbols, [Δ]; dims=1)
+        f_re = Symbolics.build_function(el.re, args; expression=Val{false})
+        f_im = Symbolics.build_function(el.im, args; expression=Val{false})
+        (args...) -> f_re(args...) + im * f_im(args...)
+    end
+    return ResponseMatrix(compiled_M, symbols, res.problem.eom.variables)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Calculate the linear response of the system for a given branch.
+Evaluates the linear response by solving the linear response ODE for each stable solution
+and input frequency in the given range.
+
+# Arguments
+- `res`: Result object containing the system's solutions
+- `nat_var::Num`: Natural variable to evaluate in the response
+- `Ω_range`: Range of frequencies to evaluate
+- `branch::Int`: Branch number to analyze
+- `show_progress=true`: Whether to show a progress bar
+
+# Returns
+- Array{P,2}: Response matrix where rows correspond to frequencies and columns to stable solutions
+"""
+function HarmonicSteadyState.get_linear_response(
+    res::HarmonicSteadyState.Result{D,S,P},
+    nat_var::Num,
+    Ω_range,
+    branch::Int;
+    show_progress=true,
+) where {D,S,P}
+    stable = HarmonicSteadyState.get_class(res, branch, "stable") # boolean array
+    !any(stable) && error("Cannot generate a spectrum - no stable solutions!")
+
+    response = ResponseMatrix(res) # the symbolic response matrix
+    C = Array{P,2}(undef, length(Ω_range), sum(stable))
+
+    # note: this could be optimized by not grabbing the entire huge dictionary every time
+    if show_progress
+        bar = Progress(
+            length(C);
+            dt=1,
+            desc="Solving the linear response ODE for each solution and input frequency ... ",
+            barlen=50,
+        )
+    end
+    for j in findall(stable)
+
+        # get response for each individual point
+        s = HarmonicSteadyState.get_single_solution(res; branch=branch, index=j)
+        for i in 1:(size(C)[1])
+            C[i, j] = HarmonicSteadyState.LinearResponse.get_response(
+                response, s, Ω_range[i]
+            )
+        end
+        show_progress ? next!(bar) : nothing
+    end
+    return C
+end
+
+end # module

--- a/ext/PlotsExt/PlotsExt.jl
+++ b/ext/PlotsExt/PlotsExt.jl
@@ -21,7 +21,7 @@ using Symbolics: Num
 using LinearAlgebra: LinearAlgebra, eigvals, eigvecs
 
 using HarmonicSteadyState.LinearResponse:
-    get_jacobian_response, get_linear_response, get_rotframe_jacobian_response
+    get_jacobian_response, get_rotframe_jacobian_response
 
 using Plots: heatmap, theme_palette, scatter, RGB, cgrad
 using Symbolics.Latexify: Latexify, latexify, @L_str

--- a/src/HarmonicSteadyState.jl
+++ b/src/HarmonicSteadyState.jl
@@ -122,7 +122,7 @@ function __init__()
         )
     end
     Base.Experimental.register_error_hint(
-        _error_hinter("HarmonicBalance", :HarmonicBalanceExt, get_response_matrix),
+        _error_hinter("HarmonicBalance", :HarmonicBalanceExt, get_linear_response),
         MethodError,
     )
     return nothing

--- a/src/LinearResponse/LinearResponse.jl
+++ b/src/LinearResponse/LinearResponse.jl
@@ -16,8 +16,7 @@ using HarmonicSteadyState:
     get_single_solution,
     get_class,
     swept_parameters,
-    _free_symbols,
-    get_response_matrix
+    _free_symbols
 
 using QuestBase: HarmonicVariable, substitute_all
 

--- a/src/LinearResponse/LinearResponse.jl
+++ b/src/LinearResponse/LinearResponse.jl
@@ -15,8 +15,7 @@ using HarmonicSteadyState:
     StateDict,
     get_single_solution,
     get_class,
-    swept_parameters,
-    _free_symbols
+    swept_parameters
 
 using QuestBase: HarmonicVariable, substitute_all
 
@@ -26,10 +25,6 @@ include("Lorentzian_spectrum.jl")
 include("response.jl")
 
 export show,
-    get_jacobian_response,
-    get_linear_response,
-    get_rotframe_jacobian_response,
-    eigenvalues,
-    eigenvectors
+    get_jacobian_response, get_rotframe_jacobian_response, eigenvalues, eigenvectors
 
 end

--- a/src/LinearResponse/response.jl
+++ b/src/LinearResponse/response.jl
@@ -71,53 +71,6 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Calculate the linear response of the system for a given branch.
-Evaluates the linear response by solving the linear response ODE for each stable solution
-and input frequency in the given range.
-
-# Arguments
-- `res`: Result object containing the system's solutions
-- `nat_var::Num`: Natural variable to evaluate in the response
-- `Ω_range`: Range of frequencies to evaluate
-- `branch::Int`: Branch number to analyze
-- `show_progress=true`: Whether to show a progress bar
-
-# Returns
-- Array{P,2}: Response matrix where rows correspond to frequencies and columns to stable solutions
-"""
-function get_linear_response(
-    res::Result{D,S,P}, nat_var::Num, Ω_range, branch::Int; show_progress=true
-) where {D,S,P}
-    stable = get_class(res, branch, "stable") # boolean array
-    !any(stable) && error("Cannot generate a spectrum - no stable solutions!")
-
-    response = ResponseMatrix(res) # the symbolic response matrix
-    C = Array{P,2}(undef, length(Ω_range), sum(stable))
-
-    # note: this could be optimized by not grabbing the entire huge dictionary every time
-    if show_progress
-        bar = Progress(
-            length(C);
-            dt=1,
-            desc="Solving the linear response ODE for each solution and input frequency ... ",
-            barlen=50,
-        )
-    end
-    for j in findall(stable)
-
-        # get response for each individual point
-        s = get_single_solution(res; branch=branch, index=j)
-        for i in 1:(size(C)[1])
-            C[i, j] = get_response(response, s, Ω_range[i])
-        end
-        show_progress ? next!(bar) : nothing
-    end
-    return C
-end
-
-"""
-$(TYPEDSIGNATURES)
-
 Calculate the rotating frame Jacobian response for a given branch.
 Computes the rotating frame Jacobian response by evaluating eigenvalues of the numerical
 Jacobian and calculating the response magnitude for each frequency in the range.
@@ -246,33 +199,6 @@ function eigenvectors(res::Result{D,S,P}, branch; class=["physical"]) where {D,S
     eigvecs_filtered = map(.*, eigenvectors, filter_branch)
 
     return eigvecs_filtered
-end
-
-"Get the response matrix corresponding to `res`.
-Any substitution rules not specified in `res` can be supplied in `rules`."
-function ResponseMatrix(res::Result; rules=Dict())
-    HarmonicBalanceExt = Base.get_extension(HarmonicSteadyState, :HarmonicBalanceExt)
-    if isnothing(HarmonicBalanceExt)
-        str = """
-        The `ResponseMatrix` method requires the HarmonicBalance.jl package to be explicitly loaded.\n
-        You can do this by simply typing `using HarmonicBalance` in your REPL,
-        or otherwise loading HarmonicBalance.jl via using or import.
-        """
-        error(str)
-    else
-        # get the symbolic response matrix
-        Symbolics.@variables Δ
-        M = HarmonicBalanceExt.get_response_matrix(res.problem.eom.natural_equation, Δ)
-        M = substitute_all(M, merge(res.fixed_parameters, rules))
-        symbols = _free_symbols(res)
-        compiled_M = map(M) do el
-            args = cat(symbols, [Δ]; dims=1)
-            f_re = Symbolics.build_function(el.re, args; expression=Val{false})
-            f_im = Symbolics.build_function(el.im, args; expression=Val{false})
-            (args...) -> f_re(args...) + im * f_im(args...)
-        end
-        return ResponseMatrix(compiled_M, symbols, res.problem.eom.variables)
-    end
 end
 
 """Evaluate the response matrix `resp` for the steady state `s` at (lab-frame) frequency `Ω`."""

--- a/src/LinearResponse/response.jl
+++ b/src/LinearResponse/response.jl
@@ -251,7 +251,8 @@ end
 "Get the response matrix corresponding to `res`.
 Any substitution rules not specified in `res` can be supplied in `rules`."
 function ResponseMatrix(res::Result; rules=Dict())
-    if isnothing(Base.get_extension(HarmonicSteadyState, :HarmonicBalanceExt))
+    HarmonicBalanceExt = Base.get_extension(HarmonicSteadyState, :HarmonicBalanceExt)
+    if isnothing(HarmonicBalanceExt)
         str = """
         The `ResponseMatrix` method requires the HarmonicBalance.jl package to be explicitly loaded.\n
         You can do this by simply typing `using HarmonicBalance` in your REPL,
@@ -261,7 +262,7 @@ function ResponseMatrix(res::Result; rules=Dict())
     else
         # get the symbolic response matrix
         Symbolics.@variables Δ
-        M = get_response_matrix(res.problem.eom.natural_equation, Δ; order=2)
+        M = HarmonicBalanceExt.get_response_matrix(res.problem.eom.natural_equation, Δ)
         M = substitute_all(M, merge(res.fixed_parameters, rules))
         symbols = _free_symbols(res)
         compiled_M = map(M) do el

--- a/src/extension_functions.jl
+++ b/src/extension_functions.jl
@@ -7,8 +7,8 @@ function plot_eigenvalues end
 function plot_rotframe_jacobian_response end
 function plot_phase_diagram end
 function plot_linear_response end
-function get_response_matrix end
 
+function get_linear_response end
 # ## Method error handling
 # We also inject a method error handler, which
 # prints a suggestion if the Proj extension is not loaded.

--- a/test/code_quality.jl
+++ b/test/code_quality.jl
@@ -22,11 +22,7 @@ end
 
 @testset "Code linting" begin
     using JET
-    rep = report_package("HarmonicSteadyState"; target_defined_modules=true)
-    @show rep
-    @test length(JET.get_reports(rep)) <= 1
-    @test_broken length(JET.get_reports(rep)) == 0
-    # JET.test_package(HarmonicSteadyState; target_defined_modules=true)
+    JET.test_package(HarmonicSteadyState; target_defined_modules=true)
 end
 
 @testset "Code quality" begin

--- a/test/code_quality.jl
+++ b/test/code_quality.jl
@@ -20,9 +20,11 @@
     end
 end
 
-@testset "Code linting" begin
-    using JET
-    JET.test_package(HarmonicSteadyState; target_defined_modules=true)
+if VERSION < v"1.12.0-beta"
+    @testset "Code linting" begin
+        using JET
+        JET.test_package(HarmonicSteadyState; target_defined_modules=true)
+    end
 end
 
 @testset "Code quality" begin


### PR DESCRIPTION
## Checklist

Thank you for contributing to `HarmonicSteadyState.jl`! Please make sure you have finished the following tasks before finishing the PR.

<!-- - [ ] Any code changes were done in a way that does not break public API. -->
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
<!-- - [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`. -->

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

Fix Jet `get_response_matrix` complaint

## Related issues or PRs

Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved followed by the issue id, e.g. fix #[id]

## Additional context
