### PR TITLE
fix: plot2D_cut along other axis

### DIFF
--- a/ext/PlotsExt/steady_states.jl
+++ b/ext/PlotsExt/steady_states.jl
@@ -191,12 +191,13 @@ function plot2D_cut(
         )
     end
 
-    X = swept_parameter(res, cut_par)
     Y = get_solutions(res, y; realify=true, class, not_class) # first transform, then filter
 
-    x_index = findfirst(sym -> string(sym) == string(cut_par), res.swept_parameters.keys)
-    branches = x_index == 1 ? Y[:, cut_par_index] : Y[cut_par_index, :]
-
+    x_index = findfirst(sym -> string(sym) == string(cut_par), res.swept_parameters.keys)    
+    branches = x_index == 1 ? Y[cut_par_index, :] : Y[:, cut_par_index]
+    other_par=x_index == 1 ? res.swept_parameters.keys[2] : res.swept_parameters.keys[1]
+    X = swept_parameter(res, other_par)
+    
     branch_data = [
         _realify(getindex.(branches, i); warning="branch " * string(k)) for
         (i, k) in enumerate(1:branch_count(res))
@@ -213,7 +214,7 @@ function plot2D_cut(
             _realify(getindex.(branches, k));
             color=k,
             label=l,
-            xlabel=latexify(string(cut_par)),
+            xlabel=latexify(string(other_par)),
             ylabel=latexify(y),
             kwargs...,
         )

--- a/ext/PlotsExt/steady_states.jl
+++ b/ext/PlotsExt/steady_states.jl
@@ -193,11 +193,11 @@ function plot2D_cut(
 
     Y = get_solutions(res, y; realify=true, class, not_class) # first transform, then filter
 
-    x_index = findfirst(sym -> string(sym) == string(cut_par), res.swept_parameters.keys)    
+    x_index = findfirst(sym -> string(sym) == string(cut_par), res.swept_parameters.keys)
     branches = x_index == 1 ? Y[cut_par_index, :] : Y[:, cut_par_index]
-    other_par=x_index == 1 ? res.swept_parameters.keys[2] : res.swept_parameters.keys[1]
+    other_par = x_index == 1 ? res.swept_parameters.keys[2] : res.swept_parameters.keys[1]
     X = swept_parameter(res, other_par)
-    
+
     branch_data = [
         _realify(getindex.(branches, i); warning="branch " * string(k)) for
         (i, k) in enumerate(1:branch_count(res))


### PR DESCRIPTION
Axes in plot2D_cut() were mixed up. Now, cuts are along the desired (other) axis instead of being along the one specified for the cut.
## Checklist

Thank you for contributing to `HarmonicSteadyState.jl`! Please make sure you have finished the following tasks before finishing the PR.

<!-- - [ ] Any code changes were done in a way that does not break public API. -->
- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
<!-- - [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`. -->

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

Describe the proposed change here.

## Related issues or PRs

Please mention the related issues or PRs here. If the PR fixes an issue, use the keyword close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved followed by the issue id, e.g. fix #[id]

## Additional context
