### PR TITLE
ci: run tests and docs on lts again

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: 'lts'
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -29,7 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.12'
+          - 'lts'
+          - '1'
         os:
           - ubuntu-latest
         arch:
@@ -59,4 +60,4 @@ jobs:
           files: lcov.info
           name: codecov-umbrella
           fail_ci_if_error: false
-        if: ${{ matrix.version == '1.12' }}
+        if: ${{ matrix.version == 'lts' }}

--- a/ext/QuantumCumulantsExt.jl
+++ b/ext/QuantumCumulantsExt.jl
@@ -128,9 +128,7 @@ function QuestBase.HarmonicEquation(MFeqs::MeanfieldEquations, parameters)
     jac = HarmonicSteadyState.get_Jacobian(eqs_jac, vars_jac)
 
     hvars = map(vars) do var
-        return HarmonicSteadyState.QuestBase.HarmonicVariable(
-            Num(var), "", "", Num(1), Num(0)
-        )
+        return QuestBase.HarmonicVariable(Num(var), "", "", Num(1), Num(0))
     end
 
     equations_lhs = map(enumerate(vars)) do (idx, var)

--- a/src/LinearResponse/LinearResponse.jl
+++ b/src/LinearResponse/LinearResponse.jl
@@ -4,8 +4,8 @@ using Printf: Printf, @printf
 using DocStringExtensions: TYPEDFIELDS, TYPEDSIGNATURES, TYPEDEF
 using ProgressMeter: ProgressMeter, Progress, next!
 
-using Symbolics: Symbolics, Num, unwrap
-using SymbolicUtils: SymbolicUtils
+using Symbolics: Symbolics, Num
+using SymbolicUtils: SymbolicUtils, unwrap
 using LinearAlgebra: LinearAlgebra, norm, eigen, eigvals, eigvecs, I
 
 using HarmonicSteadyState:


### PR DESCRIPTION
HarmonicBalance 0.17.1 is registered and supports Julia 1.10, so `test/runtests.jl`, which loads it, resolves on `lts` again. Restores `lts` in the `Tests.yml` matrix (`['lts', '1']`, with coverage uploaded from the lts job) and in `Documentation.yml`, matching the configuration from before the Symbolics 7 migration.

Includes two ownership fixes that only the lts job catches, both verified locally on 1.10.11:

- the `LinearResponse` submodule imported `unwrap` from `Symbolics` rather than from `SymbolicUtils`, which owns it.
- `QuantumCumulantsExt` reached `QuestBase` through `HarmonicSteadyState` even though it already imports `QuestBase` directly.

With these, all of `check_no_stale_explicit_imports`, `check_all_explicit_imports_via_owners`, `check_all_qualified_accesses_via_owners` and `check_no_self_qualified_accesses` pass on 1.10 for `HarmonicSteadyState` and all five of its extension modules. No version bump: these are import-provenance changes with no runtime effect.

Note this also re-enables the JET testset, which `test/code_quality.jl` gates on `VERSION < v\"1.12.0-beta\"` and which has therefore not run in CI since the matrix went 1.12-only. `JET.report_package(HarmonicSteadyState)` reports no errors on 1.10.